### PR TITLE
Add usecases to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,11 @@ NOTE: generated code currently uses ZCL_OAPI_JSON, suggest copying the implement
 - clone this repository
 - run `npm install`
 
-`npm test` = run unit tests
+### Testing
+Unit Tests: `npm test`
+Intergration Tests: `npm run integration_test`
 
-`npm run petstore` = run logic and generate petstore files in `./test_v1/generated/`
+You can try out the generation using Swagger's Petstore Example:
+- Just run `npm run petstore`
+- The output files will be generated in `./test_v1/generated/`
 
-`npm run integration_test` = run integration tests

--- a/README.md
+++ b/README.md
@@ -1,26 +1,45 @@
-# ABAP [OpenAPI](https://www.openapis.org) Client & Server Generator
+# ABAP OpenAPI Client & Server Generator
 
-- [possibility to run in browser](https://abap-openapi.github.io/web-openapi-client/)
-- possibility to run via command line(NodeJS)
-- possibility to generate for different ABAP versions(ie. Steampunk)
-- one self-contained global class + interface per OpenAPI definition
-- possible to run generation on ABAP stack
-- eventually OpenAPI v2 support, [converting v2 to v3](https://github.com/swagger-api/swagger-converter)
-- only JSON support
+ABAP OpenAPI is an [OpenAPI](https://www.openapis.org) generator tool designed to create API clients, ICF server handlers, and ICF server implementation stubs from OpenAPI documents.
+
+## Generate
+
+It is possible to generate the objects using different processes:
+- Generate via our [web client](https://abap-openapi.github.io/web-openapi-client/)
+- Generate via command line (NodeJS)
+- Generate via ABAP
+
+## Features
+
+| Feature |  |
+| --- | --- |
+| OpenAPI File Types | JSON |
+| OpenAPI Versions | v2\*, v3 |
+| ABAP Versions | v702 and up  |
+| Object Creation | one self-contained global class & interface per OpenAPI definition |
+
+\* OpenAPI v2 is currently only cabable by converting the v2 file to a v3 file. This can be done manually using the [Swagger Editor](https://editor.swagger.io/), or programmatically using [Swagger Converter](https://github.com/swagger-api/swagger-converter)
 
 NOTE: generated code currently uses ZCL_OAPI_JSON, suggest copying the implementation to a local class in the generated global class
 
-Generation is targeted to run on v702
+## Use Cases
+### API Creator
+- Write the OpenAPI document for your API so that you can generate the ICF handler and Server Implementation boilerplate
+- Use the OpenAPI document to create automatic documentation for your API
 
-Generated client code is targeted to run on v702
+### API User
+- Use any OpenAPI document to create the client class to consume external APIs
 
 ## Building/Developing
-Prerequisites = [NodeJS](https://nodejs.org) 16+
+### Prerequisites
+[NodeJS](https://nodejs.org) 16+
 
-setup `npm install`
+### Setup 
+- clone this repository
+- run `npm install`
 
 `npm test` = run unit tests
 
-`npm run petstore` = run logic and generate petstore files in `./result/`
+`npm run petstore` = run logic and generate petstore files in `./test_v1/generated/`
 
 `npm run integration_test` = run integration tests

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# abap-openapi
-
-ABAP [OpenAPI](https://www.openapis.org) Client & Server Generator in ABAP
+# ABAP [OpenAPI](https://www.openapis.org) Client & Server Generator
 
 - [possibility to run in browser](https://abap-openapi.github.io/web-openapi-client/)
 - possibility to run via command line(NodeJS)


### PR DESCRIPTION
Added the general use cases to help promote use of abap-openapi to ABAP devs that might not fully understand what it is used for.

Cleaned up organization of the README a little