### PR TITLE
compare with string to find root cause easier

### DIFF
--- a/src/utils/zcl_oapi_graph.clas.abap
+++ b/src/utils/zcl_oapi_graph.clas.abap
@@ -44,7 +44,7 @@ CLASS zcl_oapi_graph IMPLEMENTATION.
       rv_node = lv_vertex.
       RETURN.
     ENDLOOP.
-    ASSERT 1 = 'graph has cycles'.
+    ASSERT '' = 'graph has cycles'.
   ENDMETHOD.
 
   METHOD add_vertex.


### PR DESCRIPTION
When comparing to the empty string the error is:

```
Error: ASSERTION_FAILED
    at Statements.assert (/Users/gwolf/Documents/Projects/abap/abap-openapi/node_modules/@abaplint/runtime/build/src/statements/assert.js:6:15)
    at zcl_oapi_graph.pop (file:///Users/gwolf/Documents/Projects/abap/abap-openapi/output/zcl_oapi_graph.clas.mjs:58:21)
```

and not the misleading:

```
Error: CONVT_NO_NUMBER
    at toInteger (/Users/gwolf/Documents/Projects/abap/abap-openapi/node_modules/@abaplint/runtime/build/src/types/integer.js:23:19)
    at Object.eq (/Users/gwolf/Documents/Projects/abap/abap-openapi/node_modules/@abaplint/runtime/build/src/compare/eq.js:42:42)
    at zcl_oapi_graph.pop (file:///Users/gwolf/Documents/Projects/abap/abap-openapi/output/zcl_oapi_graph.clas.mjs:58:41)
```