### PR TITLE
Add response code and reason to API return value

### DIFF
--- a/src/v2/zcl_oapi_generator_v2.clas.abap
+++ b/src/v2/zcl_oapi_generator_v2.clas.abap
@@ -326,8 +326,6 @@ CLASS zcl_oapi_generator_v2 IMPLEMENTATION.
     LOOP AT ms_specification-operations INTO ls_operation.
       rv_abap = rv_abap &&
         |  METHOD { ms_input-intf }~{ ls_operation-abap_name }.\n| &&
-        |    DATA lv_code         TYPE i.\n| &&
-        |    DATA lv_message      TYPE string.\n| &&
         |    DATA lv_uri          TYPE string.\n| &&
         |    DATA ls_header       LIKE LINE OF mt_extra_headers.\n| &&
         |    DATA lv_dummy        TYPE string.\n| &&
@@ -399,8 +397,8 @@ CLASS zcl_oapi_generator_v2 IMPLEMENTATION.
         |    IF sy-subrc <> 0.\n| &&
         |      mi_client->get_last_error(\n| &&
         |        IMPORTING\n| &&
-        |          code    = lv_code\n| &&
-        |          message = lv_message ).\n| &&
+        |          code    = return-code\n| &&
+        |          message = return-reason ).\n| &&
         |      ASSERT 1 = 2.\n| &&
         |    ENDIF.\n| &&
         |\n| &&
@@ -592,21 +590,15 @@ CLASS zcl_oapi_generator_v2 IMPLEMENTATION.
               |           { lv_response_name } TYPE { lv_returning_type },\n|.
       ENDLOOP.
     ENDLOOP.
-    IF rs_returning-type IS NOT INITIAL.
-      rs_returning-type =
-        |  TYPES: BEGIN OF { lv_typename },\n| &&
-        |           code          TYPE i,\n| &&
-        |           reason        TYPE string,\n| &&
-        |{ rs_returning-type }| &&
-        |         END OF { lv_typename }.\n|.
-    ENDIF.
+    rs_returning-type =
+      |  TYPES: BEGIN OF { lv_typename },\n| &&
+      |           code          TYPE i,\n| &&
+      |           reason        TYPE string,\n| &&
+      |{ rs_returning-type }| &&
+      |         END OF { lv_typename }.\n|.
 
-    LOOP AT is_operation-responses INTO ls_response.
-      LOOP AT ls_response-content INTO ls_content.
-        rs_returning-abap = rs_returning-abap &&
-          |\n    RETURNING\n      VALUE(return) TYPE { lv_typename }|.
-        RETURN. " exit method, as only one return parameter is allowed
-      ENDLOOP.
-    ENDLOOP.
+    rs_returning-abap = rs_returning-abap &&
+      |\n    RETURNING\n      VALUE(return) TYPE { lv_typename }|.
+
   ENDMETHOD.
 ENDCLASS.

--- a/src/v2/zcl_oapi_generator_v2.clas.abap
+++ b/src/v2/zcl_oapi_generator_v2.clas.abap
@@ -405,8 +405,11 @@ CLASS zcl_oapi_generator_v2 IMPLEMENTATION.
         |    ENDIF.\n| &&
         |\n| &&
         |    lv_content_type = mi_client->response->get_content_type( ).\n| &&
-        |    mi_client->response->get_status( IMPORTING code = lv_code ).\n| &&
-        |    CASE lv_code.\n|.
+        |    mi_client->response->get_status(\n| &&
+        |      IMPORTING\n| &&
+        |        code   = return-code\n| &&
+        |        reason = return-reason ).\n| &&
+        |    CASE return-code.\n|.
 
       LOOP AT ls_operation-responses INTO ls_response.
         rv_abap = rv_abap &&
@@ -592,6 +595,8 @@ CLASS zcl_oapi_generator_v2 IMPLEMENTATION.
     IF rs_returning-type IS NOT INITIAL.
       rs_returning-type =
         |  TYPES: BEGIN OF { lv_typename },\n| &&
+        |           code          TYPE i,| &&
+        |           reason        TYPE string,| &&
         |{ rs_returning-type }| &&
         |         END OF { lv_typename }.\n|.
     ENDIF.

--- a/src/v2/zcl_oapi_generator_v2.clas.abap
+++ b/src/v2/zcl_oapi_generator_v2.clas.abap
@@ -595,8 +595,8 @@ CLASS zcl_oapi_generator_v2 IMPLEMENTATION.
     IF rs_returning-type IS NOT INITIAL.
       rs_returning-type =
         |  TYPES: BEGIN OF { lv_typename },\n| &&
-        |           code          TYPE i,| &&
-        |           reason        TYPE string,| &&
+        |           code          TYPE i,\n| &&
+        |           reason        TYPE string,\n| &&
         |{ rs_returning-type }| &&
         |         END OF { lv_typename }.\n|.
     ENDIF.

--- a/test_v2/test001/zcl_client001.clas.abap
+++ b/test_v2/test001/zcl_client001.clas.abap
@@ -30,8 +30,6 @@ CLASS zcl_client001 IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_interface001~_ping.
-    DATA lv_code         TYPE i.
-    DATA lv_message      TYPE string.
     DATA lv_uri          TYPE string.
     DATA ls_header       LIKE LINE OF mt_extra_headers.
     DATA lv_dummy        TYPE string.
@@ -59,14 +57,17 @@ CLASS zcl_client001 IMPLEMENTATION.
     IF sy-subrc <> 0.
       mi_client->get_last_error(
         IMPORTING
-          code    = lv_code
-          message = lv_message ).
+          code    = return-code
+          message = return-reason ).
       ASSERT 1 = 2.
     ENDIF.
 
     lv_content_type = mi_client->response->get_content_type( ).
-    mi_client->response->get_status( IMPORTING code = lv_code ).
-    CASE lv_code.
+    mi_client->response->get_status(
+      IMPORTING
+        code   = return-code
+        reason = return-reason ).
+    CASE return-code.
       WHEN '200'.
 * todo, no content types
       WHEN OTHERS.

--- a/test_v2/test001/zif_interface001.intf.abap
+++ b/test_v2/test001/zif_interface001.intf.abap
@@ -6,7 +6,13 @@ INTERFACE zif_interface001 PUBLIC.
 
   CONSTANTS base_path TYPE string VALUE ''.
 
+  TYPES: BEGIN OF r__ping,
+           code          TYPE i,
+           reason        TYPE string,
+         END OF r__ping.
   METHODS _ping
+    RETURNING
+      VALUE(return) TYPE r__ping
     RAISING
       cx_static_check.
 ENDINTERFACE.

--- a/test_v2/test002/zcl_client002.clas.abap
+++ b/test_v2/test002/zcl_client002.clas.abap
@@ -30,8 +30,6 @@ CLASS zcl_client002 IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_interface002~_test.
-    DATA lv_code         TYPE i.
-    DATA lv_message      TYPE string.
     DATA lv_uri          TYPE string.
     DATA ls_header       LIKE LINE OF mt_extra_headers.
     DATA lv_dummy        TYPE string.
@@ -64,14 +62,17 @@ CLASS zcl_client002 IMPLEMENTATION.
     IF sy-subrc <> 0.
       mi_client->get_last_error(
         IMPORTING
-          code    = lv_code
-          message = lv_message ).
+          code    = return-code
+          message = return-reason ).
       ASSERT 1 = 2.
     ENDIF.
 
     lv_content_type = mi_client->response->get_content_type( ).
-    mi_client->response->get_status( IMPORTING code = lv_code ).
-    CASE lv_code.
+    mi_client->response->get_status(
+      IMPORTING
+        code   = return-code
+        reason = return-reason ).
+    CASE return-code.
       WHEN '200'.
         SPLIT lv_content_type AT ';' INTO lv_content_type lv_dummy.
         CASE lv_content_type.

--- a/test_v2/test002/zif_interface002.intf.abap
+++ b/test_v2/test002/zif_interface002.intf.abap
@@ -17,6 +17,8 @@ INTERFACE zif_interface002 PUBLIC.
          END OF posttestrequest.
 
   TYPES: BEGIN OF r__test,
+           code          TYPE i,
+           reason        TYPE string,
            _200_app_json TYPE posttestresponse,
          END OF r__test.
   METHODS _test

--- a/test_v2/test003/zcl_client003.clas.abap
+++ b/test_v2/test003/zcl_client003.clas.abap
@@ -29,8 +29,6 @@ CLASS zcl_client003 IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_interface003~_test.
-    DATA lv_code         TYPE i.
-    DATA lv_message      TYPE string.
     DATA lv_uri          TYPE string.
     DATA ls_header       LIKE LINE OF mt_extra_headers.
     DATA lv_dummy        TYPE string.
@@ -63,14 +61,17 @@ CLASS zcl_client003 IMPLEMENTATION.
     IF sy-subrc <> 0.
       mi_client->get_last_error(
         IMPORTING
-          code    = lv_code
-          message = lv_message ).
+          code    = return-code
+          message = return-reason ).
       ASSERT 1 = 2.
     ENDIF.
 
     lv_content_type = mi_client->response->get_content_type( ).
-    mi_client->response->get_status( IMPORTING code = lv_code ).
-    CASE lv_code.
+    mi_client->response->get_status(
+      IMPORTING
+        code   = return-code
+        reason = return-reason ).
+    CASE return-code.
       WHEN '200'.
         SPLIT lv_content_type AT ';' INTO lv_content_type lv_dummy.
         CASE lv_content_type.

--- a/test_v2/test003/zif_interface003.intf.abap
+++ b/test_v2/test003/zif_interface003.intf.abap
@@ -37,6 +37,8 @@ INTERFACE zif_interface003 PUBLIC.
          END OF posttestrequest.
 
   TYPES: BEGIN OF r__test,
+           code          TYPE i,
+           reason        TYPE string,
            _200_app_json TYPE posttestresponse,
          END OF r__test.
   METHODS _test

--- a/test_v2/test004/zcl_client004.clas.abap
+++ b/test_v2/test004/zcl_client004.clas.abap
@@ -29,8 +29,6 @@ CLASS zcl_client004 IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_interface004~_test.
-    DATA lv_code         TYPE i.
-    DATA lv_message      TYPE string.
     DATA lv_uri          TYPE string.
     DATA ls_header       LIKE LINE OF mt_extra_headers.
     DATA lv_dummy        TYPE string.
@@ -63,14 +61,17 @@ CLASS zcl_client004 IMPLEMENTATION.
     IF sy-subrc <> 0.
       mi_client->get_last_error(
         IMPORTING
-          code    = lv_code
-          message = lv_message ).
+          code    = return-code
+          message = return-reason ).
       ASSERT 1 = 2.
     ENDIF.
 
     lv_content_type = mi_client->response->get_content_type( ).
-    mi_client->response->get_status( IMPORTING code = lv_code ).
-    CASE lv_code.
+    mi_client->response->get_status(
+      IMPORTING
+        code   = return-code
+        reason = return-reason ).
+    CASE return-code.
       WHEN '200'.
         SPLIT lv_content_type AT ';' INTO lv_content_type lv_dummy.
         CASE lv_content_type.

--- a/test_v2/test004/zif_interface004.intf.abap
+++ b/test_v2/test004/zif_interface004.intf.abap
@@ -34,6 +34,8 @@ INTERFACE zif_interface004 PUBLIC.
          END OF posttestrequest.
 
   TYPES: BEGIN OF r__test,
+           code          TYPE i,
+           reason        TYPE string,
            _200_app_json TYPE posttestresponse,
          END OF r__test.
   METHODS _test

--- a/test_v2/test005/zcl_client005.clas.abap
+++ b/test_v2/test005/zcl_client005.clas.abap
@@ -30,8 +30,6 @@ CLASS zcl_client005 IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_interface005~_test.
-    DATA lv_code         TYPE i.
-    DATA lv_message      TYPE string.
     DATA lv_uri          TYPE string.
     DATA ls_header       LIKE LINE OF mt_extra_headers.
     DATA lv_dummy        TYPE string.
@@ -64,14 +62,17 @@ CLASS zcl_client005 IMPLEMENTATION.
     IF sy-subrc <> 0.
       mi_client->get_last_error(
         IMPORTING
-          code    = lv_code
-          message = lv_message ).
+          code    = return-code
+          message = return-reason ).
       ASSERT 1 = 2.
     ENDIF.
 
     lv_content_type = mi_client->response->get_content_type( ).
-    mi_client->response->get_status( IMPORTING code = lv_code ).
-    CASE lv_code.
+    mi_client->response->get_status(
+      IMPORTING
+        code   = return-code
+        reason = return-reason ).
+    CASE return-code.
       WHEN '200'.
         SPLIT lv_content_type AT ';' INTO lv_content_type lv_dummy.
         CASE lv_content_type.

--- a/test_v2/test005/zif_interface005.intf.abap
+++ b/test_v2/test005/zif_interface005.intf.abap
@@ -17,6 +17,8 @@ INTERFACE zif_interface005 PUBLIC.
          END OF posttestrequest.
 
   TYPES: BEGIN OF r__test,
+           code          TYPE i,
+           reason        TYPE string,
            _200_app_json TYPE posttestresponse,
          END OF r__test.
   METHODS _test

--- a/test_v2/test006/zcl_client006.clas.abap
+++ b/test_v2/test006/zcl_client006.clas.abap
@@ -29,8 +29,6 @@ CLASS zcl_client006 IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_interface006~_test.
-    DATA lv_code         TYPE i.
-    DATA lv_message      TYPE string.
     DATA lv_uri          TYPE string.
     DATA ls_header       LIKE LINE OF mt_extra_headers.
     DATA lv_dummy        TYPE string.
@@ -63,14 +61,17 @@ CLASS zcl_client006 IMPLEMENTATION.
     IF sy-subrc <> 0.
       mi_client->get_last_error(
         IMPORTING
-          code    = lv_code
-          message = lv_message ).
+          code    = return-code
+          message = return-reason ).
       ASSERT 1 = 2.
     ENDIF.
 
     lv_content_type = mi_client->response->get_content_type( ).
-    mi_client->response->get_status( IMPORTING code = lv_code ).
-    CASE lv_code.
+    mi_client->response->get_status(
+      IMPORTING
+        code   = return-code
+        reason = return-reason ).
+    CASE return-code.
       WHEN '200'.
         SPLIT lv_content_type AT ';' INTO lv_content_type lv_dummy.
         CASE lv_content_type.

--- a/test_v2/test006/zif_interface006.intf.abap
+++ b/test_v2/test006/zif_interface006.intf.abap
@@ -37,6 +37,8 @@ INTERFACE zif_interface006 PUBLIC.
          END OF posttestrequest.
 
   TYPES: BEGIN OF r__test,
+           code          TYPE i,
+           reason        TYPE string,
            _200_app_json TYPE posttestresponse,
          END OF r__test.
   METHODS _test

--- a/test_v2/test007/zcl_client007.clas.abap
+++ b/test_v2/test007/zcl_client007.clas.abap
@@ -29,8 +29,6 @@ CLASS zcl_client007 IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_interface007~_test.
-    DATA lv_code         TYPE i.
-    DATA lv_message      TYPE string.
     DATA lv_uri          TYPE string.
     DATA ls_header       LIKE LINE OF mt_extra_headers.
     DATA lv_dummy        TYPE string.
@@ -63,14 +61,17 @@ CLASS zcl_client007 IMPLEMENTATION.
     IF sy-subrc <> 0.
       mi_client->get_last_error(
         IMPORTING
-          code    = lv_code
-          message = lv_message ).
+          code    = return-code
+          message = return-reason ).
       ASSERT 1 = 2.
     ENDIF.
 
     lv_content_type = mi_client->response->get_content_type( ).
-    mi_client->response->get_status( IMPORTING code = lv_code ).
-    CASE lv_code.
+    mi_client->response->get_status(
+      IMPORTING
+        code   = return-code
+        reason = return-reason ).
+    CASE return-code.
       WHEN '200'.
         SPLIT lv_content_type AT ';' INTO lv_content_type lv_dummy.
         CASE lv_content_type.

--- a/test_v2/test007/zif_interface007.intf.abap
+++ b/test_v2/test007/zif_interface007.intf.abap
@@ -34,6 +34,8 @@ INTERFACE zif_interface007 PUBLIC.
          END OF posttestrequest.
 
   TYPES: BEGIN OF r__test,
+           code          TYPE i,
+           reason        TYPE string,
            _200_app_json TYPE posttestresponse,
          END OF r__test.
   METHODS _test

--- a/test_v2/test008/zcl_client008.clas.abap
+++ b/test_v2/test008/zcl_client008.clas.abap
@@ -30,8 +30,6 @@ CLASS zcl_client008 IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_interface008~find_pets_by_status.
-    DATA lv_code         TYPE i.
-    DATA lv_message      TYPE string.
     DATA lv_uri          TYPE string.
     DATA ls_header       LIKE LINE OF mt_extra_headers.
     DATA lv_dummy        TYPE string.
@@ -60,14 +58,17 @@ CLASS zcl_client008 IMPLEMENTATION.
     IF sy-subrc <> 0.
       mi_client->get_last_error(
         IMPORTING
-          code    = lv_code
-          message = lv_message ).
+          code    = return-code
+          message = return-reason ).
       ASSERT 1 = 2.
     ENDIF.
 
     lv_content_type = mi_client->response->get_content_type( ).
-    mi_client->response->get_status( IMPORTING code = lv_code ).
-    CASE lv_code.
+    mi_client->response->get_status(
+      IMPORTING
+        code   = return-code
+        reason = return-reason ).
+    CASE return-code.
       WHEN '200'.
         SPLIT lv_content_type AT ';' INTO lv_content_type lv_dummy.
         CASE lv_content_type.

--- a/test_v2/test008/zif_interface008.intf.abap
+++ b/test_v2/test008/zif_interface008.intf.abap
@@ -29,6 +29,8 @@ INTERFACE zif_interface008 PUBLIC.
   TYPES response_find_pets_by_status TYPE STANDARD TABLE OF pet WITH DEFAULT KEY.
 
   TYPES: BEGIN OF r_find_pets_by_status,
+           code          TYPE i,
+           reason        TYPE string,
            _200_app_json TYPE response_find_pets_by_status,
            _200_app_xml TYPE response_find_pets_by_status,
          END OF r_find_pets_by_status.

--- a/test_v2/test009/zcl_client009.clas.abap
+++ b/test_v2/test009/zcl_client009.clas.abap
@@ -30,8 +30,6 @@ CLASS zcl_client009 IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_interface009~_test.
-    DATA lv_code         TYPE i.
-    DATA lv_message      TYPE string.
     DATA lv_uri          TYPE string.
     DATA ls_header       LIKE LINE OF mt_extra_headers.
     DATA lv_dummy        TYPE string.
@@ -60,14 +58,17 @@ CLASS zcl_client009 IMPLEMENTATION.
     IF sy-subrc <> 0.
       mi_client->get_last_error(
         IMPORTING
-          code    = lv_code
-          message = lv_message ).
+          code    = return-code
+          message = return-reason ).
       ASSERT 1 = 2.
     ENDIF.
 
     lv_content_type = mi_client->response->get_content_type( ).
-    mi_client->response->get_status( IMPORTING code = lv_code ).
-    CASE lv_code.
+    mi_client->response->get_status(
+      IMPORTING
+        code   = return-code
+        reason = return-reason ).
+    CASE return-code.
       WHEN '200'.
 * todo, no content types
       WHEN OTHERS.

--- a/test_v2/test009/zif_interface009.intf.abap
+++ b/test_v2/test009/zif_interface009.intf.abap
@@ -6,9 +6,15 @@ INTERFACE zif_interface009 PUBLIC.
 
   CONSTANTS base_path TYPE string VALUE ''.
 
+  TYPES: BEGIN OF r__test,
+           code          TYPE i,
+           reason        TYPE string,
+         END OF r__test.
   METHODS _test
     IMPORTING
       _top TYPE i OPTIONAL
+    RETURNING
+      VALUE(return) TYPE r__test
     RAISING
       cx_static_check.
 ENDINTERFACE.

--- a/test_v2/test010/zcl_client010.clas.abap
+++ b/test_v2/test010/zcl_client010.clas.abap
@@ -30,8 +30,6 @@ CLASS zcl_client010 IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_interface010~create_user.
-    DATA lv_code         TYPE i.
-    DATA lv_message      TYPE string.
     DATA lv_uri          TYPE string.
     DATA ls_header       LIKE LINE OF mt_extra_headers.
     DATA lv_dummy        TYPE string.
@@ -61,14 +59,17 @@ CLASS zcl_client010 IMPLEMENTATION.
     IF sy-subrc <> 0.
       mi_client->get_last_error(
         IMPORTING
-          code    = lv_code
-          message = lv_message ).
+          code    = return-code
+          message = return-reason ).
       ASSERT 1 = 2.
     ENDIF.
 
     lv_content_type = mi_client->response->get_content_type( ).
-    mi_client->response->get_status( IMPORTING code = lv_code ).
-    CASE lv_code.
+    mi_client->response->get_status(
+      IMPORTING
+        code   = return-code
+        reason = return-reason ).
+    CASE return-code.
       WHEN 'default'.
         SPLIT lv_content_type AT ';' INTO lv_content_type lv_dummy.
         CASE lv_content_type.

--- a/test_v2/test010/zif_interface010.intf.abap
+++ b/test_v2/test010/zif_interface010.intf.abap
@@ -7,6 +7,8 @@ INTERFACE zif_interface010 PUBLIC.
   CONSTANTS base_path TYPE string VALUE ''.
 
   TYPES: BEGIN OF r_create_user,
+           code          TYPE i,
+           reason        TYPE string,
            _default_app_json TYPE string,
          END OF r_create_user.
   METHODS create_user

--- a/test_v2/test011/zcl_client011.clas.abap
+++ b/test_v2/test011/zcl_client011.clas.abap
@@ -30,8 +30,6 @@ CLASS zcl_client011 IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_interface011~_foo_param.
-    DATA lv_code         TYPE i.
-    DATA lv_message      TYPE string.
     DATA lv_uri          TYPE string.
     DATA ls_header       LIKE LINE OF mt_extra_headers.
     DATA lv_dummy        TYPE string.
@@ -60,14 +58,17 @@ CLASS zcl_client011 IMPLEMENTATION.
     IF sy-subrc <> 0.
       mi_client->get_last_error(
         IMPORTING
-          code    = lv_code
-          message = lv_message ).
+          code    = return-code
+          message = return-reason ).
       ASSERT 1 = 2.
     ENDIF.
 
     lv_content_type = mi_client->response->get_content_type( ).
-    mi_client->response->get_status( IMPORTING code = lv_code ).
-    CASE lv_code.
+    mi_client->response->get_status(
+      IMPORTING
+        code   = return-code
+        reason = return-reason ).
+    CASE return-code.
       WHEN '200'.
 * todo, no content types
       WHEN OTHERS.

--- a/test_v2/test011/zif_interface011.intf.abap
+++ b/test_v2/test011/zif_interface011.intf.abap
@@ -6,9 +6,15 @@ INTERFACE zif_interface011 PUBLIC.
 
   CONSTANTS base_path TYPE string VALUE ''.
 
+  TYPES: BEGIN OF r__foo_param,
+           code          TYPE i,
+           reason        TYPE string,
+         END OF r__foo_param.
   METHODS _foo_param
     IMPORTING
       param TYPE string
+    RETURNING
+      VALUE(return) TYPE r__foo_param
     RAISING
       cx_static_check.
 ENDINTERFACE.

--- a/test_v2/test012/zcl_client012.clas.abap
+++ b/test_v2/test012/zcl_client012.clas.abap
@@ -30,8 +30,6 @@ CLASS zcl_client012 IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_interface012~_something.
-    DATA lv_code         TYPE i.
-    DATA lv_message      TYPE string.
     DATA lv_uri          TYPE string.
     DATA ls_header       LIKE LINE OF mt_extra_headers.
     DATA lv_dummy        TYPE string.
@@ -62,14 +60,17 @@ CLASS zcl_client012 IMPLEMENTATION.
     IF sy-subrc <> 0.
       mi_client->get_last_error(
         IMPORTING
-          code    = lv_code
-          message = lv_message ).
+          code    = return-code
+          message = return-reason ).
       ASSERT 1 = 2.
     ENDIF.
 
     lv_content_type = mi_client->response->get_content_type( ).
-    mi_client->response->get_status( IMPORTING code = lv_code ).
-    CASE lv_code.
+    mi_client->response->get_status(
+      IMPORTING
+        code   = return-code
+        reason = return-reason ).
+    CASE return-code.
       WHEN '200'.
 * todo, no content types
       WHEN OTHERS.

--- a/test_v2/test012/zif_interface012.intf.abap
+++ b/test_v2/test012/zif_interface012.intf.abap
@@ -6,9 +6,15 @@ INTERFACE zif_interface012 PUBLIC.
 
   CONSTANTS base_path TYPE string VALUE ''.
 
+  TYPES: BEGIN OF r__something,
+           code          TYPE i,
+           reason        TYPE string,
+         END OF r__something.
   METHODS _something
     IMPORTING
       user_agent TYPE string
+    RETURNING
+      VALUE(return) TYPE r__something
     RAISING
       cx_static_check.
 ENDINTERFACE.

--- a/test_v2/test013/zcl_client013.clas.abap
+++ b/test_v2/test013/zcl_client013.clas.abap
@@ -29,8 +29,6 @@ CLASS zcl_client013 IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_interface013~_foo_param_another.
-    DATA lv_code         TYPE i.
-    DATA lv_message      TYPE string.
     DATA lv_uri          TYPE string.
     DATA ls_header       LIKE LINE OF mt_extra_headers.
     DATA lv_dummy        TYPE string.
@@ -60,14 +58,17 @@ CLASS zcl_client013 IMPLEMENTATION.
     IF sy-subrc <> 0.
       mi_client->get_last_error(
         IMPORTING
-          code    = lv_code
-          message = lv_message ).
+          code    = return-code
+          message = return-reason ).
       ASSERT 1 = 2.
     ENDIF.
 
     lv_content_type = mi_client->response->get_content_type( ).
-    mi_client->response->get_status( IMPORTING code = lv_code ).
-    CASE lv_code.
+    mi_client->response->get_status(
+      IMPORTING
+        code   = return-code
+        reason = return-reason ).
+    CASE return-code.
       WHEN '200'.
 * todo, no content types
       WHEN OTHERS.

--- a/test_v2/test013/zif_interface013.intf.abap
+++ b/test_v2/test013/zif_interface013.intf.abap
@@ -5,10 +5,16 @@ INTERFACE zif_interface013 PUBLIC.
 
   CONSTANTS base_path TYPE string VALUE ''.
 
+  TYPES: BEGIN OF r__foo_param_another,
+           code          TYPE i,
+           reason        TYPE string,
+         END OF r__foo_param_another.
   METHODS _foo_param_another
     IMPORTING
       param TYPE string
       another TYPE string
+    RETURNING
+      VALUE(return) TYPE r__foo_param_another
     RAISING
       cx_static_check.
 ENDINTERFACE.

--- a/test_v2/test014/zcl_client014.clas.abap
+++ b/test_v2/test014/zcl_client014.clas.abap
@@ -29,8 +29,6 @@ CLASS zcl_client014 IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_interface014~ping_summary.
-    DATA lv_code         TYPE i.
-    DATA lv_message      TYPE string.
     DATA lv_uri          TYPE string.
     DATA ls_header       LIKE LINE OF mt_extra_headers.
     DATA lv_dummy        TYPE string.
@@ -58,14 +56,17 @@ CLASS zcl_client014 IMPLEMENTATION.
     IF sy-subrc <> 0.
       mi_client->get_last_error(
         IMPORTING
-          code    = lv_code
-          message = lv_message ).
+          code    = return-code
+          message = return-reason ).
       ASSERT 1 = 2.
     ENDIF.
 
     lv_content_type = mi_client->response->get_content_type( ).
-    mi_client->response->get_status( IMPORTING code = lv_code ).
-    CASE lv_code.
+    mi_client->response->get_status(
+      IMPORTING
+        code   = return-code
+        reason = return-reason ).
+    CASE return-code.
       WHEN '200'.
 * todo, no content types
       WHEN OTHERS.

--- a/test_v2/test014/zif_interface014.intf.abap
+++ b/test_v2/test014/zif_interface014.intf.abap
@@ -5,8 +5,14 @@ INTERFACE zif_interface014 PUBLIC.
 
   CONSTANTS base_path TYPE string VALUE ''.
 
+  TYPES: BEGIN OF r_ping_summary,
+           code          TYPE i,
+           reason        TYPE string,
+         END OF r_ping_summary.
   "! ping summary
   METHODS ping_summary
+    RETURNING
+      VALUE(return) TYPE r_ping_summary
     RAISING
       cx_static_check.
 ENDINTERFACE.

--- a/test_v2/test015/zcl_client015.clas.abap
+++ b/test_v2/test015/zcl_client015.clas.abap
@@ -29,8 +29,6 @@ CLASS zcl_client015 IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_interface015~_array.
-    DATA lv_code         TYPE i.
-    DATA lv_message      TYPE string.
     DATA lv_uri          TYPE string.
     DATA ls_header       LIKE LINE OF mt_extra_headers.
     DATA lv_dummy        TYPE string.
@@ -58,14 +56,17 @@ CLASS zcl_client015 IMPLEMENTATION.
     IF sy-subrc <> 0.
       mi_client->get_last_error(
         IMPORTING
-          code    = lv_code
-          message = lv_message ).
+          code    = return-code
+          message = return-reason ).
       ASSERT 1 = 2.
     ENDIF.
 
     lv_content_type = mi_client->response->get_content_type( ).
-    mi_client->response->get_status( IMPORTING code = lv_code ).
-    CASE lv_code.
+    mi_client->response->get_status(
+      IMPORTING
+        code   = return-code
+        reason = return-reason ).
+    CASE return-code.
       WHEN '200'.
         SPLIT lv_content_type AT ';' INTO lv_content_type lv_dummy.
         CASE lv_content_type.

--- a/test_v2/test015/zif_interface015.intf.abap
+++ b/test_v2/test015/zif_interface015.intf.abap
@@ -16,6 +16,8 @@ INTERFACE zif_interface015 PUBLIC.
          END OF something.
 
   TYPES: BEGIN OF r__array,
+           code          TYPE i,
+           reason        TYPE string,
            _200_app_json TYPE something,
          END OF r__array.
   METHODS _array

--- a/test_v2/test016/zcl_client016.clas.abap
+++ b/test_v2/test016/zcl_client016.clas.abap
@@ -29,8 +29,6 @@ CLASS zcl_client016 IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_interface016~_create_dog.
-    DATA lv_code         TYPE i.
-    DATA lv_message      TYPE string.
     DATA lv_uri          TYPE string.
     DATA ls_header       LIKE LINE OF mt_extra_headers.
     DATA lv_dummy        TYPE string.
@@ -62,14 +60,17 @@ CLASS zcl_client016 IMPLEMENTATION.
     IF sy-subrc <> 0.
       mi_client->get_last_error(
         IMPORTING
-          code    = lv_code
-          message = lv_message ).
+          code    = return-code
+          message = return-reason ).
       ASSERT 1 = 2.
     ENDIF.
 
     lv_content_type = mi_client->response->get_content_type( ).
-    mi_client->response->get_status( IMPORTING code = lv_code ).
-    CASE lv_code.
+    mi_client->response->get_status(
+      IMPORTING
+        code   = return-code
+        reason = return-reason ).
+    CASE return-code.
       WHEN '200'.
         SPLIT lv_content_type AT ';' INTO lv_content_type lv_dummy.
         CASE lv_content_type.

--- a/test_v2/test016/zif_interface016.intf.abap
+++ b/test_v2/test016/zif_interface016.intf.abap
@@ -21,6 +21,8 @@ INTERFACE zif_interface016 PUBLIC.
          END OF response.
 
   TYPES: BEGIN OF r__create_dog,
+           code          TYPE i,
+           reason        TYPE string,
            _200_app_json TYPE response,
          END OF r__create_dog.
   METHODS _create_dog

--- a/test_v2/test017/zcl_client017.clas.abap
+++ b/test_v2/test017/zcl_client017.clas.abap
@@ -29,8 +29,6 @@ CLASS zcl_client017 IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_interface017~_array.
-    DATA lv_code         TYPE i.
-    DATA lv_message      TYPE string.
     DATA lv_uri          TYPE string.
     DATA ls_header       LIKE LINE OF mt_extra_headers.
     DATA lv_dummy        TYPE string.
@@ -58,14 +56,17 @@ CLASS zcl_client017 IMPLEMENTATION.
     IF sy-subrc <> 0.
       mi_client->get_last_error(
         IMPORTING
-          code    = lv_code
-          message = lv_message ).
+          code    = return-code
+          message = return-reason ).
       ASSERT 1 = 2.
     ENDIF.
 
     lv_content_type = mi_client->response->get_content_type( ).
-    mi_client->response->get_status( IMPORTING code = lv_code ).
-    CASE lv_code.
+    mi_client->response->get_status(
+      IMPORTING
+        code   = return-code
+        reason = return-reason ).
+    CASE return-code.
       WHEN '400'.
         SPLIT lv_content_type AT ';' INTO lv_content_type lv_dummy.
         CASE lv_content_type.

--- a/test_v2/test017/zif_interface017.intf.abap
+++ b/test_v2/test017/zif_interface017.intf.abap
@@ -21,6 +21,8 @@ INTERFACE zif_interface017 PUBLIC.
          END OF error.
 
   TYPES: BEGIN OF r__array,
+           code          TYPE i,
+           reason        TYPE string,
            _400_app_json TYPE error,
          END OF r__array.
   METHODS _array

--- a/test_v2/test018/zcl_client018.clas.abap
+++ b/test_v2/test018/zcl_client018.clas.abap
@@ -29,8 +29,6 @@ CLASS zcl_client018 IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_interface018~_create_dog.
-    DATA lv_code         TYPE i.
-    DATA lv_message      TYPE string.
     DATA lv_uri          TYPE string.
     DATA ls_header       LIKE LINE OF mt_extra_headers.
     DATA lv_dummy        TYPE string.
@@ -62,14 +60,17 @@ CLASS zcl_client018 IMPLEMENTATION.
     IF sy-subrc <> 0.
       mi_client->get_last_error(
         IMPORTING
-          code    = lv_code
-          message = lv_message ).
+          code    = return-code
+          message = return-reason ).
       ASSERT 1 = 2.
     ENDIF.
 
     lv_content_type = mi_client->response->get_content_type( ).
-    mi_client->response->get_status( IMPORTING code = lv_code ).
-    CASE lv_code.
+    mi_client->response->get_status(
+      IMPORTING
+        code   = return-code
+        reason = return-reason ).
+    CASE return-code.
       WHEN '200'.
 * todo, no content types
       WHEN OTHERS.

--- a/test_v2/test018/zif_interface018.intf.abap
+++ b/test_v2/test018/zif_interface018.intf.abap
@@ -20,9 +20,15 @@ INTERFACE zif_interface018 PUBLIC.
            operations TYPE STANDARD TABLE OF operation WITH DEFAULT KEY,
          END OF body_create_dog.
 
+  TYPES: BEGIN OF r__create_dog,
+           code          TYPE i,
+           reason        TYPE string,
+         END OF r__create_dog.
   METHODS _create_dog
     IMPORTING
       body TYPE body_create_dog
+    RETURNING
+      VALUE(return) TYPE r__create_dog
     RAISING
       cx_static_check.
 ENDINTERFACE.

--- a/test_v2/test019/zcl_client019.clas.abap
+++ b/test_v2/test019/zcl_client019.clas.abap
@@ -29,8 +29,6 @@ CLASS zcl_client019 IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_interface019~send_binary.
-    DATA lv_code         TYPE i.
-    DATA lv_message      TYPE string.
     DATA lv_uri          TYPE string.
     DATA ls_header       LIKE LINE OF mt_extra_headers.
     DATA lv_dummy        TYPE string.
@@ -60,14 +58,17 @@ CLASS zcl_client019 IMPLEMENTATION.
     IF sy-subrc <> 0.
       mi_client->get_last_error(
         IMPORTING
-          code    = lv_code
-          message = lv_message ).
+          code    = return-code
+          message = return-reason ).
       ASSERT 1 = 2.
     ENDIF.
 
     lv_content_type = mi_client->response->get_content_type( ).
-    mi_client->response->get_status( IMPORTING code = lv_code ).
-    CASE lv_code.
+    mi_client->response->get_status(
+      IMPORTING
+        code   = return-code
+        reason = return-reason ).
+    CASE return-code.
       WHEN '200'.
 * todo, no content types
       WHEN OTHERS.

--- a/test_v2/test019/zif_interface019.intf.abap
+++ b/test_v2/test019/zif_interface019.intf.abap
@@ -5,9 +5,15 @@ INTERFACE zif_interface019 PUBLIC.
 
   CONSTANTS base_path TYPE string VALUE ''.
 
+  TYPES: BEGIN OF r_send_binary,
+           code          TYPE i,
+           reason        TYPE string,
+         END OF r_send_binary.
   METHODS send_binary
     IMPORTING
       body TYPE xstring
+    RETURNING
+      VALUE(return) TYPE r_send_binary
     RAISING
       cx_static_check.
 ENDINTERFACE.

--- a/test_v2/test020/zcl_client020.clas.abap
+++ b/test_v2/test020/zcl_client020.clas.abap
@@ -29,8 +29,6 @@ CLASS zcl_client020 IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_interface020~send.
-    DATA lv_code         TYPE i.
-    DATA lv_message      TYPE string.
     DATA lv_uri          TYPE string.
     DATA ls_header       LIKE LINE OF mt_extra_headers.
     DATA lv_dummy        TYPE string.
@@ -59,14 +57,17 @@ CLASS zcl_client020 IMPLEMENTATION.
     IF sy-subrc <> 0.
       mi_client->get_last_error(
         IMPORTING
-          code    = lv_code
-          message = lv_message ).
+          code    = return-code
+          message = return-reason ).
       ASSERT 1 = 2.
     ENDIF.
 
     lv_content_type = mi_client->response->get_content_type( ).
-    mi_client->response->get_status( IMPORTING code = lv_code ).
-    CASE lv_code.
+    mi_client->response->get_status(
+      IMPORTING
+        code   = return-code
+        reason = return-reason ).
+    CASE return-code.
       WHEN '200'.
 * todo, no content types
       WHEN OTHERS.

--- a/test_v2/test020/zif_interface020.intf.abap
+++ b/test_v2/test020/zif_interface020.intf.abap
@@ -5,9 +5,15 @@ INTERFACE zif_interface020 PUBLIC.
 
   CONSTANTS base_path TYPE string VALUE ''.
 
+  TYPES: BEGIN OF r_send,
+           code          TYPE i,
+           reason        TYPE string,
+         END OF r_send.
   METHODS send
     IMPORTING
       body TYPE any
+    RETURNING
+      VALUE(return) TYPE r_send
     RAISING
       cx_static_check.
 ENDINTERFACE.

--- a/test_v2/test021/zcl_client021.clas.abap
+++ b/test_v2/test021/zcl_client021.clas.abap
@@ -29,8 +29,6 @@ CLASS zcl_client021 IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_interface021~send.
-    DATA lv_code         TYPE i.
-    DATA lv_message      TYPE string.
     DATA lv_uri          TYPE string.
     DATA ls_header       LIKE LINE OF mt_extra_headers.
     DATA lv_dummy        TYPE string.
@@ -59,14 +57,17 @@ CLASS zcl_client021 IMPLEMENTATION.
     IF sy-subrc <> 0.
       mi_client->get_last_error(
         IMPORTING
-          code    = lv_code
-          message = lv_message ).
+          code    = return-code
+          message = return-reason ).
       ASSERT 1 = 2.
     ENDIF.
 
     lv_content_type = mi_client->response->get_content_type( ).
-    mi_client->response->get_status( IMPORTING code = lv_code ).
-    CASE lv_code.
+    mi_client->response->get_status(
+      IMPORTING
+        code   = return-code
+        reason = return-reason ).
+    CASE return-code.
       WHEN '200'.
 * todo, no content types
       WHEN OTHERS.

--- a/test_v2/test021/zif_interface021.intf.abap
+++ b/test_v2/test021/zif_interface021.intf.abap
@@ -5,9 +5,15 @@ INTERFACE zif_interface021 PUBLIC.
 
   CONSTANTS base_path TYPE string VALUE ''.
 
+  TYPES: BEGIN OF r_send,
+           code          TYPE i,
+           reason        TYPE string,
+         END OF r_send.
   METHODS send
     IMPORTING
       body TYPE char4
+    RETURNING
+      VALUE(return) TYPE r_send
     RAISING
       cx_static_check.
 ENDINTERFACE.

--- a/test_v2/test022/zcl_client022.clas.abap
+++ b/test_v2/test022/zcl_client022.clas.abap
@@ -29,8 +29,6 @@ CLASS zcl_client022 IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD zif_interface022~send_text.
-    DATA lv_code         TYPE i.
-    DATA lv_message      TYPE string.
     DATA lv_uri          TYPE string.
     DATA ls_header       LIKE LINE OF mt_extra_headers.
     DATA lv_dummy        TYPE string.
@@ -60,14 +58,17 @@ CLASS zcl_client022 IMPLEMENTATION.
     IF sy-subrc <> 0.
       mi_client->get_last_error(
         IMPORTING
-          code    = lv_code
-          message = lv_message ).
+          code    = return-code
+          message = return-reason ).
       ASSERT 1 = 2.
     ENDIF.
 
     lv_content_type = mi_client->response->get_content_type( ).
-    mi_client->response->get_status( IMPORTING code = lv_code ).
-    CASE lv_code.
+    mi_client->response->get_status(
+      IMPORTING
+        code   = return-code
+        reason = return-reason ).
+    CASE return-code.
       WHEN '200'.
 * todo, no content types
       WHEN OTHERS.

--- a/test_v2/test022/zif_interface022.intf.abap
+++ b/test_v2/test022/zif_interface022.intf.abap
@@ -5,9 +5,15 @@ INTERFACE zif_interface022 PUBLIC.
 
   CONSTANTS base_path TYPE string VALUE ''.
 
+  TYPES: BEGIN OF r_send_text,
+           code          TYPE i,
+           reason        TYPE string,
+         END OF r_send_text.
   METHODS send_text
     IMPORTING
       body TYPE string
+    RETURNING
+      VALUE(return) TYPE r_send_text
     RAISING
       cx_static_check.
 ENDINTERFACE.


### PR DESCRIPTION
Put response code and reason into return types. Allows better handling and debugging of unexpected responses and simplified handling by caller if they wish.

![image](https://github.com/user-attachments/assets/6905c9db-16f5-46e6-a738-024ab5164d7c)

Note, I can also replace `lv_code` and `lv_message` in this part as the vars are not used anywhere else, lmk
```abap
    IF sy-subrc <> 0.
      mi_client->get_last_error(
        IMPORTING
          code    = lv_code
          message = lv_message ).
      ASSERT 1 = 2.
    ENDIF.
```
